### PR TITLE
:sparkles: update: 로그인, splash 페이지 애니메이션 구현

### DIFF
--- a/src/app/_lib/postSignup.ts
+++ b/src/app/_lib/postSignup.ts
@@ -24,11 +24,7 @@ export async function postSignup(userData) {
     phoneNumber: phoneNumber,
   });
 
-  console.log(api_params);
-
   const accessToken = LocalStorage.getItem('accessToken');
-  // const accessToken =
-  // ''
 
   try {
     const res = await fetch(`${apiUrl}/signup`, {

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -5,34 +5,50 @@ import { LoginWrapper } from './style';
 import Image from 'next/image';
 import Button from '@/app/_component/atom/button/button';
 import { Colors, Icons, Images } from '@globalStyles';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 
 export default function Login(): React.JSX.Element {
-  const [userData, setUserData] = useState(null);
-  // const router = useRouter();
   const handleKakaoLogin = () => {
     window.open('https://api-dev.vacgom.co.kr/api/v1/oauth/kakao');
   };
+  const [showContent, setShowContent] = useState(false);
+  const [showTitle, setShowTitle] = useState(false);
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setShowContent(true); // 2초 후에 showContent 상태를 true로 변경합니다
+    }, 2000);
+
+    return () => clearTimeout(timer);
+  }, []); // useEffect가 처음 한 번만 실행되도록 빈 배열을 전달합니다
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setShowTitle(true); // 0.4초 후에 showContent 상태를 true로 변경합니다
+    }, 400);
+
+    return () => clearTimeout(timer);
+  }, []); // useEffect가 처음 한 번만 실행되도록 빈 배열을 전달합니다
 
   return (
     <LoginWrapper>
-      <div className="main">
-        <div className="title">
+      <div className={`main ${showContent ? 'show-content' : ''}`}>
+        <div className={`title ${showTitle ? 'show-title' : ''}`}>
           <Image src={Images.splash} alt={'백곰'} />
           <div className="sub_title">백신아, 곰아워!</div>
         </div>
       </div>
-      <div className="splash_image">
+      <div className={`splash_image ${showContent ? 'show-content' : ''} `}>
         <Image
           className={'vacgom_icon'}
           src={Images.vacgom01}
           alt={'백곰 스플래시 이미지'}
         />
       </div>
-      <div className="bottom">
+      <div className={`bottom ${showContent ? 'show-content' : ''} `}>
         <Button
-          label={'카카오톡 계정으로 가입하기'}
+          label={'카카오로 계속하기'}
           variant={'kakao'}
           size={'kakao'}
           prevIcon={Icons.kakao}

--- a/src/app/login/style.ts
+++ b/src/app/login/style.ts
@@ -12,7 +12,23 @@ export const LoginWrapper = styled.main`
     align-items: center;
     display: flex;
     justify-content: center;
+
+    &.show-content > .title {
+      transform: translateY(0);
+    }
+    &.show-content {
+      display: flex; /* show-content 클래스가 적용된 경우에만 flex로 설정됩니다 */
+    }
+
     & > .title {
+      transition:
+        transform 0.7s ease,
+        opacity 0.2s ease;
+      transform: translateY(200px);
+      opacity: 0;
+      &.show-title {
+        opacity: 1;
+      }
       & > .sub_title {
         margin-top: 10px;
 
@@ -21,12 +37,30 @@ export const LoginWrapper = styled.main`
       }
     }
   }
+  & > .bottom {
+    display: none;
+  }
+  & > .splash_image > img {
+    visibility: hidden;
+    top: 300px; /* 원하는 위치로 지정합니다 */
+  }
+
+  .show-content {
+    display: block; /* show-content 클래스가 적용되면 나머지 요소들이 보이도록 설정합니다 */
+  }
+  .show-content > img {
+    visibility: visible;
+    top: 21px; /* show-content 클래스가 적용되면 원하는 위치로 이동됩니다 */
+    display: block;
+  }
+
   & > .splash_image {
     display: flex;
     & > .vacgom_icon {
       width: 100%;
       position: relative;
-      top: 10px;
+      //top: 300px; /* 원하는 위치로 지정합니다 */
+      transition: top 1s cubic-bezier(0.18, 0.69, 0.32, 1.28);
       z-index: 0;
     }
   }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,34 +2,58 @@
 import * as React from 'react';
 import { HomeWrap } from './style';
 import Image from 'next/image';
+import Button from '@/app/_component/atom/button/button';
 import { Colors, Icons, Images } from '@globalStyles';
-import { useRouter } from 'next/navigation';
+import { useEffect, useState } from 'react';
 
 export default function Home(): React.JSX.Element {
-  const router = useRouter();
+  const handleKakaoLogin = () => {
+    window.open('https://api-dev.vacgom.co.kr/api/v1/oauth/kakao');
+  };
+  const [showContent, setShowContent] = useState(false);
+  const [showTitle, setShowTitle] = useState(false);
 
-  React.useEffect(() => {
-    const timeoutId = setTimeout(() => {
-      router.push('/login');
-    }, 3000);
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setShowContent(true); // 2초 후에 showContent 상태를 true로 변경합니다
+    }, 2000);
 
-    return () => clearTimeout(timeoutId);
-  }, []);
+    return () => clearTimeout(timer);
+  }, []); // useEffect가 처음 한 번만 실행되도록 빈 배열을 전달합니다
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setShowTitle(true); // 0.4초 후에 showContent 상태를 true로 변경합니다
+    }, 400);
+
+    return () => clearTimeout(timer);
+  }, []); // useEffect가 처음 한 번만 실행되도록 빈 배열을 전달합니다
 
   return (
     <HomeWrap>
-      <div className="main">
-        <div className="title">
+      <div className={`main ${showContent ? 'show-content' : ''}`}>
+        <div className={`title ${showTitle ? 'show-title' : ''}`}>
           <Image src={Images.splash} alt={'백곰'} />
           <div className="sub_title">백신아, 곰아워!</div>
         </div>
       </div>
-      <div className="splash_image">
+      <div className={`splash_image ${showContent ? 'show-content' : ''} `}>
         <Image
           className={'vacgom_icon'}
           src={Images.vacgom01}
           alt={'백곰 스플래시 이미지'}
         />
+      </div>
+      <div className={`bottom ${showContent ? 'show-content' : ''} `}>
+        <Button
+          label={'카카오로 계속하기'}
+          variant={'kakao'}
+          size={'kakao'}
+          prevIcon={Icons.kakao}
+          iconSize={'20'}
+          onClick={handleKakaoLogin}
+        />
+        <a className="privacy">개인정보처리방침</a>
       </div>
     </HomeWrap>
   );

--- a/src/app/signup/info/page.tsx
+++ b/src/app/signup/info/page.tsx
@@ -43,21 +43,18 @@ export default function Signup(): React.JSX.Element {
   /**
    *  이전 페이지 데이터 끌고 오는
    */
-  if (typeof window !== 'undefined') {
-    useEffect(() => {
-      let id = SecureLocalStorage.getItem('id');
-      let password = SecureLocalStorage.getItem('password');
-      console.log('secure', id, password);
+  useEffect(() => {
+    let id = SecureLocalStorage.getItem('id');
+    let password = SecureLocalStorage.getItem('password');
+    console.log('secure', id, password);
 
-      setParams({
-        ...params,
-        id,
-        password,
-      });
-    }, []);
-  }
+    setParams({
+      ...params,
+      id,
+      password,
+    });
+  }, []);
 
-  console.log(params);
   /**
    *  api 호출
    */

--- a/src/app/style.ts
+++ b/src/app/style.ts
@@ -7,11 +7,28 @@ export const HomeWrap = styled.main`
   text-align: center;
 
   & > .main {
-    height: 60%;
+    padding-top: 2rem;
+    height: 37vh;
     align-items: center;
     display: flex;
     justify-content: center;
+
+    &.show-content > .title {
+      transform: translateY(0);
+    }
+    &.show-content {
+      display: flex; /* show-content 클래스가 적용된 경우에만 flex로 설정됩니다 */
+    }
+
     & > .title {
+      transition:
+        transform 0.7s ease,
+        opacity 0.2s ease;
+      transform: translateY(200px);
+      opacity: 0;
+      &.show-title {
+        opacity: 1;
+      }
       & > .sub_title {
         margin-top: 10px;
 
@@ -20,13 +37,53 @@ export const HomeWrap = styled.main`
       }
     }
   }
+  & > .bottom {
+    display: none;
+  }
+  & > .splash_image > img {
+    visibility: hidden;
+    top: 300px; /* 원하는 위치로 지정합니다 */
+  }
+
+  .show-content {
+    display: block; /* show-content 클래스가 적용되면 나머지 요소들이 보이도록 설정합니다 */
+  }
+  .show-content > img {
+    visibility: visible;
+    top: 21px; /* show-content 클래스가 적용되면 원하는 위치로 이동됩니다 */
+    display: block;
+  }
+
   & > .splash_image {
     display: flex;
     & > .vacgom_icon {
       width: 100%;
-      bottom: 0;
-      left: 0;
-      position: absolute;
+      position: relative;
+      //top: 300px; /* 원하는 위치로 지정합니다 */
+      transition: top 1s cubic-bezier(0.18, 0.69, 0.32, 1.28);
+      z-index: 0;
+    }
+  }
+
+  & > .bottom {
+    & > button {
+      position: relative;
+      z-index: 1;
+      margin-bottom: 10px;
+    }
+    & > .privacy {
+      ${fontGenerator('14px', '600', '16px', '-0.3px')}
+      color: ${Colors.Gray50};
+      cursor: pointer;
+    }
+    padding: 0 20px;
+  }
+
+  @media screen and (max-height: 718px) {
+    & > .main {
+      padding-top: 1rem;
+      height: 28vh;
+      transition: 0.2s;
     }
   }
 `;


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🎋 작업 중인 브랜치
- feat/vachistory_api 에서 작업을 해버렸네요..!

### 🔑 주요 작업사항
- 스플래시 -> 로그인 페이지 수정했씁니다
- 기존 /login 을 없애고 맨 처음 페이지 / 에 스플래시에서 바로 로그인 ui 넘어가도록 변경했습니다.
- 화면 피그마 기준 귀여운 애니메이션도 적용했어요. 

### 🏞 (Optional) 참고 자료
- 스크린샷을 첨부해주세요.

https://github.com/goormthon-Univ/2024_BEOTKKOTTHON_TEAM_4_FE/assets/88662427/c9fa359f-3c23-4786-a295-3461dc5434da


### 관련 이슈
- 

### 꼭 확인해 주세요!!
- 